### PR TITLE
Fix for Linux compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,9 @@ configure_file(${CMAKE_SOURCE_DIR}/version.in ${CMAKE_BINARY_DIR}/version.hpp @O
 # instruct CMake to build a shared library from all of the source files
 add_library(camp ${CAMP_SRCS})
 
+# required standard level (needed to pass -std=c++11 to gcc and clang)
+set_property(TARGET camp PROPERTY CXX_STANDARD 11)
+
 # define the export macro
 if(BUILD_SHARED_LIBS)
     set_target_properties(camp PROPERTIES DEFINE_SYMBOL CAMP_EXPORTS)

--- a/include/camp/stringid.hpp
+++ b/include/camp/stringid.hpp
@@ -33,7 +33,7 @@
 //[-------------------------------------------------------]
 //[ C++ compiler keywords                                 ]
 //[-------------------------------------------------------]
-#ifdef WIN32
+#if defined(_MSC_VER)
 	/**
 	*  @brief
 	*    Force the compiler to inline something
@@ -42,7 +42,7 @@
 	*    - Do only use this when you really have to, usually it's best to let the compiler decide by using the standard keyword "inline"
 	*/
 	#define FORCEINLINE __forceinline
-#elif LINUX
+#elif defined(__clang__) || defined(__GNUG__)
 	/**
 	*  @brief
 	*    Force the compiler to inline something
@@ -50,7 +50,7 @@
 	*  @note
 	*    - Do only use this when you really have to, usually it's best to let the compiler decide by using the standard keyword "inline"
 	*/
-	#define FORCEINLINE __attribute__((always_inline))
+	#define FORCEINLINE inline __attribute__((always_inline))
 #elif __APPLE__
 	/**
 	*  @brief


### PR DESCRIPTION
I've ran into some problems with compiling on Linux with clang. I've found some issues in the build and the source and fixed them (the commit messages explain the rationale of the changes.). 
Also, I'm not sure about the error branch when defining FORCEINLINE. Does the library really need the forced inline feature that its absence would make it build erroneously? If not, I'd suggest defining `FORCEINLINE` to be simply `inline` as a graceful fallback (perhaps while also emitting a warning). With these two commits I was able to successfully build with clang 3.6.0 on Arch Linux x64.
