### PR TITLE
Fixing test build

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,6 +90,9 @@ add_definitions(-DBOOST_TEST_NO_LIB)
 # instruct CMake to build an executable from all of the source files
 add_executable(camptest ${CAMP_TEST_SRCS})
 
+# required standard level (needed to pass -std=c++11 to gcc and clang)
+set_property(TARGET camptest PROPERTY CXX_STANDARD 11)
+
 # define d suffix on windows
 if(WIN32)
     set_target_properties(camptest PROPERTIES DEBUG_POSTFIX d)

--- a/test/tagholder.cpp
+++ b/test/tagholder.cpp
@@ -13,10 +13,10 @@
 ** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 ** copies of the Software, and to permit persons to whom the Software is
 ** furnished to do so, subject to the following conditions:
-** 
+**
 ** The above copyright notice and this permission notice shall be included in
 ** all copies or substantial portions of the Software.
-** 
+**
 ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -64,9 +64,9 @@ BOOST_AUTO_TEST_CASE(get)
     BOOST_CHECK_EQUAL(metaclass->hasTag("b"), true);
     BOOST_CHECK_EQUAL(metaclass->hasTag("x"), false);
 
-    BOOST_CHECK_NO_THROW(metaclass->tagId(0));
-    BOOST_CHECK_NO_THROW(metaclass->tagId(1));
-    BOOST_CHECK_THROW(metaclass->tagId(100), camp::OutOfRange);
+    BOOST_CHECK_NO_THROW(metaclass->getTagEntryByIndex(0));
+    BOOST_CHECK_NO_THROW(metaclass->getTagEntryByIndex(1));
+    BOOST_CHECK_THROW(metaclass->getTagEntryByIndex(100), camp::OutOfRange);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
The test project did not compile, this pull request fixes that.
- Updated a function name in the tagholder tests which caused the build to fail
- Added C++11 to properly build with clang/gcc 
