### PR TITLE
Updated camp-xml to work with latest changes

### DIFF
--- a/include/camp-xml/common.hpp
+++ b/include/camp-xml/common.hpp
@@ -15,10 +15,10 @@
 ** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 ** copies of the Software, and to permit persons to whom the Software is
 ** furnished to do so, subject to the following conditions:
-** 
+**
 ** The above copyright notice and this permission notice shall be included in
 ** all copies or substantial portions of the Software.
-** 
+**
 ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -58,7 +58,7 @@ namespace detail
  * \param exclude Tag to exclude from the serialization process
  */
 template <typename Proxy>
-void serialize(const UserObject& object, typename Proxy::NodeType node, const Value& exclude);
+void serialize(const UserObject& object, typename Proxy::NodeType node, const char* exclude = nullptr);
 
 /**
  * \brief Deserialize a CAMP object from XML elements
@@ -75,7 +75,7 @@ void serialize(const UserObject& object, typename Proxy::NodeType node, const Va
  * \param exclude Tag to exclude from the deserialization process
  */
 template <typename Proxy>
-void deserialize(const UserObject& object, typename Proxy::NodeType node, const Value& exclude);
+void deserialize(const UserObject& object, typename Proxy::NodeType node, const char* exclude = nullptr);
 
 } // namespace detail
 

--- a/include/camp-xml/common.inl
+++ b/include/camp-xml/common.inl
@@ -15,10 +15,10 @@
 ** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 ** copies of the Software, and to permit persons to whom the Software is
 ** furnished to do so, subject to the following conditions:
-** 
+**
 ** The above copyright notice and this permission notice shall be included in
 ** all copies or substantial portions of the Software.
-** 
+**
 ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,17 +37,17 @@ namespace detail
 {
 //-------------------------------------------------------------------------------------------------
 template <typename Proxy>
-void serialize(const UserObject& object, typename Proxy::NodeType node, const Value& exclude)
+void serialize(const UserObject& object, typename Proxy::NodeType node, const char* exclude)
 {
     // Iterate over the object's properties using its metaclass
     const Class& metaclass = object.getClass();
+
     for (std::size_t i = 0; i < metaclass.propertyCount(); ++i)
     {
-        const Property& property = metaclass.property(i);
+        const Property& property = metaclass.getPropertyByIndex(i);
 
         // If the property has the exclude tag, ignore it
-        if ((exclude != Value::nothing) && property.hasTag(exclude))
-            continue;
+        if (exclude && property.hasTag(StringId(exclude))) { continue; }
 
         // Create a child node for the new property
         typename Proxy::NodeType child = Proxy::addChild(node, property.name());
@@ -95,16 +95,16 @@ void serialize(const UserObject& object, typename Proxy::NodeType node, const Va
 
 //-------------------------------------------------------------------------------------------------
 template <typename Proxy>
-void deserialize(const UserObject& object, typename Proxy::NodeType node, const Value& exclude)
+void deserialize(const UserObject& object, typename Proxy::NodeType node, const char* exclude)
 {
     // Iterate over the object's properties using its metaclass
     const Class& metaclass = object.getClass();
     for (std::size_t i = 0; i < metaclass.propertyCount(); ++i)
     {
-        const Property& property = metaclass.property(i);
+        const Property& property = metaclass.getPropertyByIndex(i);
 
         // If the property has the exclude tag, ignore it
-        if ((exclude != Value::nothing) && property.hasTag(exclude))
+        if (exclude && property.hasTag(StringId(exclude)))
             continue;
 
         // Find the child node corresponding to the new property

--- a/include/camp-xml/rapidxml.hpp
+++ b/include/camp-xml/rapidxml.hpp
@@ -15,10 +15,10 @@
 ** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 ** copies of the Software, and to permit persons to whom the Software is
 ** furnished to do so, subject to the following conditions:
-** 
+**
 ** The above copyright notice and this permission notice shall be included in
 ** all copies or substantial portions of the Software.
-** 
+**
 ** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 ** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 ** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -104,7 +104,7 @@ struct RapidXml
  * \param node Parent for the generated XML nodes
  * \param exclude Tag to exclude from the serialization process
  */
-inline void serialize(const UserObject& object, rapidxml::xml_node<>* node, const Value& exclude = Value::nothing)
+inline void serialize(const UserObject& object, rapidxml::xml_node<>* node, const char* exclude = nullptr)
 {
     detail::serialize<detail::RapidXml>(object, node, exclude);
 }
@@ -126,7 +126,7 @@ inline void serialize(const UserObject& object, rapidxml::xml_node<>* node, cons
  * \param node XML node to parse
  * \param exclude Tag to exclude from the deserialization process
  */
-inline void deserialize(const UserObject& object, rapidxml::xml_node<>* node, const Value& exclude = Value::nothing)
+inline void deserialize(const UserObject& object, rapidxml::xml_node<>* node, const char* exclude = nullptr)
 {
     detail::deserialize<detail::RapidXml>(object, node, exclude);
 }


### PR DESCRIPTION
Updated camp-xml to work with latest changes.
Changed tag type to ordinary string instead of the generic Value type
Changed property() to getPropertyByIndex because the latter was not
compiling anymore.
Tested with the rapidxml backend (as a side note: it might be a good idea to remove support for multiple backends and provide a single interface for xml serialization).
